### PR TITLE
Use Eclipse Temurin instead of Adopt OpenJDK

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: maven
     - name: Run the Maven verify phase
       run: mvn --batch-mode --update-snapshots verify


### PR DESCRIPTION
Adopt OpenJDK has been merged into Eclipse Temurin, so it will no longer receive any updates.

https://github.com/actions/setup-java#supported-distributions